### PR TITLE
build(deps): bump anyhow to 1.0.103 for RUSTSEC-2026-0190

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,9 +119,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.101"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "ar_archive_writer"


### PR DESCRIPTION
## Why

Closes #100.

`anyhow 1.0.101` is affected by **RUSTSEC-2026-0190** — an unsoundness in `Error::downcast_mut()` that violates borrow rules (UB / memory-corruption category) when context is added via `Error::context` and the returned error is later downcast mutably.

## Change

Bump `anyhow` to `1.0.103` in `Cargo.lock`. The advisory's patched range is `>= 1.0.103`, so this exactly clears it. No source changes required — the workspace declares `anyhow = "1"`.

## Verification

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — 370 passed, 0 failed
- Advisory patched range confirmed from the RustSec DB: `patched = [">= 1.0.103"]`