### PR TITLE
Promote test → main (2 commits)

### DIFF
--- a/.github/actions/report-scan-failure/action.yaml
+++ b/.github/actions/report-scan-failure/action.yaml
@@ -2,9 +2,11 @@
 
 name: "Report or resolve scan failure"
 description: >
-  Files (or bumps) a board-ready issue when a scheduled scan step genuinely fails, or closes it once
-  the scan is green again and nobody has claimed it yet. Dedupes on the issue title, so re-runs of a
-  still-failing scan never pile up duplicate issues.
+  Files (or bumps) a `security-audit`-labeled issue when a scheduled scan step genuinely fails, or
+  closes it once the scan is green again and nobody has claimed it yet. Dedupes on the issue title,
+  so re-runs of a still-failing scan never pile up duplicate issues. The label deliberately keeps
+  these off the Engineering board by default (Decision #66) — promote one manually with `dx project
+  add` if it turns into real, multi-session work.
 inputs:
   mode:
     description: "report (scan just failed) or resolve (scan just passed)"

--- a/.github/actions/report-scan-failure/run.sh
+++ b/.github/actions/report-scan-failure/run.sh
@@ -10,6 +10,14 @@ existing="$(gh issue list --repo "$REPO" --state open --search "\"${TITLE}\"" \
 
 case "$MODE" in
 report)
+  # security-audit deliberately keeps these off the Engineering board (issue-templates/
+  # add-to-project.yaml excludes it) — see Decision #66:
+  # https://github.com/orgs/qualithm/discussions/66. The label must exist before `gh issue
+  # create --label` can attach it, so ensure it every run; --force makes this idempotent.
+  gh label create security-audit --repo "$REPO" --color "b60205" --force \
+    --description "Automated scan failure filed by report-scan-failure; kept off the Engineering board (Decision #66)" \
+    >/dev/null
+
   if [[ -n "$existing" ]]; then
     gh issue comment "$existing" --repo "$REPO" --body "Still failing as of ${RUN_URL}."
     echo "report-scan-failure: bumped existing issue #${existing}"
@@ -30,7 +38,7 @@ addressing the finding.
 
 ### Links
 - Failing run: ${RUN_URL}"
-    url="$(gh issue create --repo "$REPO" --title "$TITLE" --body "$body")"
+    url="$(gh issue create --repo "$REPO" --title "$TITLE" --body "$body" --label security-audit)"
     echo "report-scan-failure: filed ${url}"
   fi
   ;;

--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -17,3 +17,7 @@ jobs:
         with:
           project-url: https://github.com/orgs/qualithm/projects/3
           github-token: ${{ steps.app.outputs.token }}
+          # Automated scan-failure issues (report-scan-failure) stay off the board by
+          # default — see Decision #66: https://github.com/orgs/qualithm/discussions/66.
+          labeled: security-audit
+          label-operator: NOT

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3153,7 +3153,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "sagitta"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/sagitta"]
 
 [workspace.package]
-version = "0.1.9"
+version = "0.1.10"
 edition = "2024"
 description = "Rust framework for building analytical data services on Arrow Flight and DataFusion."
 license = "Apache-2.0"

--- a/crates/sagitta/src/interceptor.rs
+++ b/crates/sagitta/src/interceptor.rs
@@ -20,6 +20,25 @@ pub struct QueryInterception {
   pub batches: Vec<RecordBatch>,
 }
 
+/// Request context describing the caller that issued an intercepted statement.
+///
+/// Passed to the `*_with_context` interceptor methods so an embedder can
+/// attribute a statement to the authenticated caller (for example, to record an
+/// audit principal). The struct is `#[non_exhaustive]`: construct it with
+/// [`InterceptContext::default`] and set the fields you need, so new fields can
+/// be added without breaking embedders.
+#[derive(Debug, Clone, Default)]
+#[non_exhaustive]
+pub struct InterceptContext {
+  /// Authenticated principal (username) that issued the statement, if any.
+  ///
+  /// `None` when the statement was issued anonymously or the engine is invoked
+  /// outside an authenticated request.
+  pub principal: Option<String>,
+  /// Whether the caller is limited to read-only access.
+  pub read_only: bool,
+}
+
 /// A hook consulted by the SQL engine before its default statement handling.
 ///
 /// An interceptor lets an embedder own dialect extensions and custom execution
@@ -48,6 +67,46 @@ pub trait StatementInterceptor: Send + Sync {
   /// Returns an error if the interceptor recognized the query but failed to
   /// execute it.
   async fn intercept_query(&self, sql: &str) -> SqlResult<Option<QueryInterception>>;
+
+  /// Context-aware variant of [`intercept_update`](Self::intercept_update).
+  ///
+  /// The SQL engine calls this method, passing the [`InterceptContext`] for the
+  /// request that issued `sql`. The default implementation ignores the context
+  /// and delegates to [`intercept_update`](Self::intercept_update), so existing
+  /// interceptors keep working unchanged; override it to read the caller.
+  ///
+  /// # Errors
+  ///
+  /// Returns an error if the interceptor recognized the statement but failed to
+  /// execute it.
+  async fn intercept_update_with_context(
+    &self,
+    ctx: &InterceptContext,
+    sql: &str,
+  ) -> SqlResult<Option<i64>> {
+    let _ = ctx;
+    self.intercept_update(sql).await
+  }
+
+  /// Context-aware variant of [`intercept_query`](Self::intercept_query).
+  ///
+  /// The SQL engine calls this method, passing the [`InterceptContext`] for the
+  /// request that issued `sql`. The default implementation ignores the context
+  /// and delegates to [`intercept_query`](Self::intercept_query), so existing
+  /// interceptors keep working unchanged; override it to read the caller.
+  ///
+  /// # Errors
+  ///
+  /// Returns an error if the interceptor recognized the query but failed to
+  /// execute it.
+  async fn intercept_query_with_context(
+    &self,
+    ctx: &InterceptContext,
+    sql: &str,
+  ) -> SqlResult<Option<QueryInterception>> {
+    let _ = ctx;
+    self.intercept_query(sql).await
+  }
 }
 
 /// Shared handle to a registered [`StatementInterceptor`].

--- a/crates/sagitta/src/lib.rs
+++ b/crates/sagitta/src/lib.rs
@@ -19,7 +19,9 @@ mod types;
 pub use auth::{AccessLevel, AuthToken, InMemoryUserStore, User, UserStore};
 pub use config::{Config, LoggingConfig, ServerConfig, TlsConfig};
 pub use error::{Error, Result};
-pub use interceptor::{QueryInterception, SharedInterceptor, StatementInterceptor};
+pub use interceptor::{
+  InterceptContext, QueryInterception, SharedInterceptor, StatementInterceptor,
+};
 pub use memory::MemoryStore;
 pub use server::Sagitta;
 pub use service::{CustomAction, SagittaService};

--- a/crates/sagitta/src/service.rs
+++ b/crates/sagitta/src/service.rs
@@ -31,7 +31,7 @@ use tonic::{Request, Response, Status, Streaming};
 use tracing::{debug, info, warn};
 use x509_parser::prelude::*;
 
-use crate::interceptor::SharedInterceptor;
+use crate::interceptor::{InterceptContext, SharedInterceptor};
 use crate::metadata::{DEFAULT_CATALOG, DEFAULT_SCHEMA, MetadataEngine, MetadataQuery};
 use crate::sql::{
   EndSavepoint, SqlEngine, create_metadata_ticket, create_prepared_statement_result,
@@ -263,6 +263,14 @@ impl SagittaService {
     self
       .authenticate_mtls(request)
       .ok_or_else(|| Status::unauthenticated("missing authorization header or client certificate"))
+  }
+
+  /// Convert an authenticated user into an [`InterceptContext`].
+  fn intercept_context(user: &User) -> InterceptContext {
+    InterceptContext {
+      principal: Some(user.username.clone()),
+      read_only: !user.can_write(),
+    }
   }
 
   /// Convert a stored dataset to a FlightInfo.
@@ -512,7 +520,11 @@ impl SagittaService {
   /// Inner implementation of do_put that works with any stream.
   /// This allows testing without tonic's Streaming type.
   #[allow(clippy::result_large_err)]
-  async fn do_put_inner<S>(&self, mut stream: S) -> Result<PutResult, Status>
+  async fn do_put_inner<S>(
+    &self,
+    mut stream: S,
+    ctx: &InterceptContext,
+  ) -> Result<PutResult, Status>
   where
     S: Stream<Item = Result<FlightData, Status>> + Unpin + Send + 'static,
   {
@@ -532,7 +544,7 @@ impl SagittaService {
     if let Some(cmd) = descriptor.command_bytes() {
       // Check if this command includes parameter data
       return self
-        .do_put_cmd_with_stream(cmd.clone(), first, stream)
+        .do_put_cmd_with_stream(cmd.clone(), first, stream, ctx)
         .await;
     }
 
@@ -604,6 +616,7 @@ impl SagittaService {
     cmd: bytes::Bytes,
     first: FlightData,
     stream: S,
+    ctx: &InterceptContext,
   ) -> Result<PutResult, Status>
   where
     S: Stream<Item = Result<FlightData, Status>> + Unpin + Send + 'static,
@@ -618,7 +631,7 @@ impl SagittaService {
           .await
       }
       // For other commands, delegate to the simpler handler
-      _ => self.do_put_cmd(cmd).await,
+      _ => self.do_put_cmd(cmd, ctx).await,
     }
   }
 
@@ -684,14 +697,21 @@ impl SagittaService {
 
   /// Handle Flight SQL commands via CMD descriptor.
   #[allow(clippy::result_large_err)]
-  async fn get_flight_info_cmd(&self, cmd: bytes::Bytes) -> Result<Response<FlightInfo>, Status> {
+  async fn get_flight_info_cmd(
+    &self,
+    cmd: bytes::Bytes,
+    ctx: &InterceptContext,
+  ) -> Result<Response<FlightInfo>, Status> {
     let command = SqlEngine::parse_command(&cmd)?;
 
     match command {
       Command::CommandStatementQuery(query_cmd) => {
         debug!(query = %query_cmd.query, "CommandStatementQuery");
 
-        let result = self.sql_engine.execute_statement_query(&query_cmd).await?;
+        let result = self
+          .sql_engine
+          .execute_statement_query_with_context(&query_cmd, ctx)
+          .await?;
 
         // Create ticket with statement handle
         let ticket_bytes = create_statement_ticket(result.handle);
@@ -1114,7 +1134,11 @@ impl SagittaService {
 
   /// Handle Flight SQL commands via CMD descriptor in DoPut.
   #[allow(clippy::result_large_err)]
-  async fn do_put_cmd(&self, cmd: bytes::Bytes) -> Result<PutResult, Status> {
+  async fn do_put_cmd(
+    &self,
+    cmd: bytes::Bytes,
+    ctx: &InterceptContext,
+  ) -> Result<PutResult, Status> {
     let command = SqlEngine::parse_command(&cmd)?;
 
     match command {
@@ -1123,7 +1147,7 @@ impl SagittaService {
 
         let result = self
           .sql_engine
-          .execute_statement_update(&update_cmd)
+          .execute_statement_update_with_context(&update_cmd, ctx)
           .await?;
 
         // Return DoPutUpdateResult in app_metadata
@@ -1184,6 +1208,7 @@ impl SagittaService {
   async fn do_get_statement_query(
     &self,
     ticket: &TicketStatementQuery,
+    ctx: &InterceptContext,
   ) -> Result<BoxedFlightStream<FlightData>, Status> {
     let handle = &ticket.statement_handle;
     let handle_str = String::from_utf8_lossy(handle);
@@ -1223,7 +1248,7 @@ impl SagittaService {
       debug!(handle = %handle_str, "getting statement query data stream");
       self
         .sql_engine
-        .get_statement_query_data_stream(ticket)
+        .get_statement_query_data_stream_with_context(ticket, ctx)
         .await?
     };
 
@@ -1374,12 +1399,13 @@ impl FlightServiceTrait for SagittaService {
     &self,
     request: Request<FlightDescriptor>,
   ) -> Result<Response<FlightInfo>, Status> {
-    self.authenticate_request(&request)?;
+    let user = self.authenticate_request(&request)?;
     let descriptor = request.into_inner();
 
     // Handle CMD descriptors (Flight SQL commands)
     if let Some(cmd_bytes) = descriptor.command_bytes() {
-      return self.get_flight_info_cmd(cmd_bytes.clone()).await;
+      let ctx = Self::intercept_context(&user);
+      return self.get_flight_info_cmd(cmd_bytes.clone(), &ctx).await;
     }
 
     // Handle PATH descriptors (regular datasets)
@@ -1403,13 +1429,14 @@ impl FlightServiceTrait for SagittaService {
     &self,
     request: Request<FlightDescriptor>,
   ) -> Result<Response<PollInfo>, Status> {
-    self.authenticate_request(&request)?;
+    let user = self.authenticate_request(&request)?;
     let descriptor = request.into_inner();
 
     // Handle CMD descriptors (Flight SQL commands)
     let info = if let Some(cmd_bytes) = descriptor.command_bytes() {
+      let ctx = Self::intercept_context(&user);
       self
-        .get_flight_info_cmd(cmd_bytes.clone())
+        .get_flight_info_cmd(cmd_bytes.clone(), &ctx)
         .await?
         .into_inner()
     } else {
@@ -1470,13 +1497,14 @@ impl FlightServiceTrait for SagittaService {
   type DoGetStream = BoxedFlightStream<FlightData>;
 
   async fn do_get(&self, request: Request<Ticket>) -> Result<Response<Self::DoGetStream>, Status> {
-    self.authenticate_request(&request)?;
+    let user = self.authenticate_request(&request)?;
     let ticket = request.into_inner();
 
     // Try to parse as TicketStatementQuery (Flight SQL)
     if let Ok(stmt_ticket) = TicketStatementQuery::decode(ticket.ticket.as_ref()) {
       debug!("do_get: TicketStatementQuery");
-      let stream = self.do_get_statement_query(&stmt_ticket).await?;
+      let ctx = Self::intercept_context(&user);
+      let stream = self.do_get_statement_query(&stmt_ticket, &ctx).await?;
       return Ok(Response::new(stream));
     }
 
@@ -1519,8 +1547,9 @@ impl FlightServiceTrait for SagittaService {
       return Err(Status::permission_denied("write access required"));
     }
 
+    let ctx = Self::intercept_context(&user);
     let stream = request.into_inner();
-    let result = self.do_put_inner(stream).await?;
+    let result = self.do_put_inner(stream, &ctx).await?;
     let stream = futures::stream::once(async { Ok(result) });
     Ok(Response::new(Box::pin(stream)))
   }
@@ -1985,6 +2014,77 @@ mod tests {
       .await
       .unwrap();
     assert_eq!(result.record_count, 5);
+  }
+
+  #[test]
+  fn test_intercept_context_from_user() {
+    let full = User::new("alice", AccessLevel::FullAccess);
+    let ctx = SagittaService::intercept_context(&full);
+    assert_eq!(ctx.principal.as_deref(), Some("alice"));
+    assert!(!ctx.read_only);
+
+    let reader = User::new("bob", AccessLevel::ReadOnly);
+    let ctx = SagittaService::intercept_context(&reader);
+    assert_eq!(ctx.principal.as_deref(), Some("bob"));
+    assert!(ctx.read_only);
+  }
+
+  #[tokio::test]
+  async fn test_do_put_cmd_threads_principal_to_interceptor() {
+    use crate::interceptor::{QueryInterception, StatementInterceptor};
+    use crate::sql::SqlResult;
+    use arrow_flight::sql::{CommandStatementUpdate, ProstMessageExt};
+
+    #[derive(Default)]
+    struct RecordingInterceptor {
+      seen: std::sync::Mutex<Vec<Option<String>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl StatementInterceptor for RecordingInterceptor {
+      async fn intercept_update(&self, _sql: &str) -> SqlResult<Option<i64>> {
+        Ok(None)
+      }
+      async fn intercept_query(&self, _sql: &str) -> SqlResult<Option<QueryInterception>> {
+        Ok(None)
+      }
+      async fn intercept_update_with_context(
+        &self,
+        ctx: &InterceptContext,
+        sql: &str,
+      ) -> SqlResult<Option<i64>> {
+        if sql.contains("DELETE") {
+          self.seen.lock().unwrap().push(ctx.principal.clone());
+          return Ok(Some(3));
+        }
+        Ok(None)
+      }
+    }
+
+    let interceptor = Arc::new(RecordingInterceptor::default());
+    let store: Arc<dyn crate::Store> = Arc::new(crate::MemoryStore::new());
+    let service =
+      SagittaService::with_user_store(store, Arc::new(InMemoryUserStore::with_test_users()))
+        .await
+        .with_interceptor(interceptor.clone());
+
+    let cmd = CommandStatementUpdate {
+      query: "DELETE FROM whatever".to_string(),
+      transaction_id: None,
+    };
+    let cmd_bytes: bytes::Bytes = cmd.as_any().encode_to_vec().into();
+    let ctx = InterceptContext {
+      principal: Some("carol".to_string()),
+      read_only: false,
+    };
+    let result = service.do_put_cmd(cmd_bytes, &ctx).await.unwrap();
+
+    let update = DoPutUpdateResult::decode(result.app_metadata.as_ref()).unwrap();
+    assert_eq!(update.record_count, 3);
+    assert_eq!(
+      interceptor.seen.lock().unwrap().as_slice(),
+      &[Some("carol".to_string())]
+    );
   }
 
   #[test]
@@ -2796,7 +2896,10 @@ mod tests {
     flight_data[0].app_metadata = Bytes::from_static(b"req-meta-123");
 
     let stream = futures::stream::iter(flight_data.into_iter().map(Ok));
-    let result = service.do_put_inner(stream).await.unwrap();
+    let result = service
+      .do_put_inner(stream, &InterceptContext::default())
+      .await
+      .unwrap();
 
     // The store's response metadata is returned to the client unchanged.
     assert_eq!(result.app_metadata, Bytes::from_static(b"req-meta-123"));
@@ -2840,7 +2943,10 @@ mod tests {
 
     // Create stream and call do_put_inner
     let stream = futures::stream::iter(flight_data.into_iter().map(Ok));
-    let result = service.do_put_inner(stream).await.unwrap();
+    let result = service
+      .do_put_inner(stream, &InterceptContext::default())
+      .await
+      .unwrap();
 
     assert!(result.app_metadata.is_empty());
 
@@ -2896,7 +3002,10 @@ mod tests {
 
     let flight_data: Vec<FlightData> = flight_stream.map(|r| r.unwrap()).collect().await;
     let stream = futures::stream::iter(flight_data.into_iter().map(Ok));
-    service.do_put_inner(stream).await.unwrap();
+    service
+      .do_put_inner(stream, &InterceptContext::default())
+      .await
+      .unwrap();
 
     // Get data back
     let ticket = Ticket::new("roundtrip".as_bytes().to_vec());
@@ -2923,7 +3032,9 @@ mod tests {
     // Empty stream
     let stream = futures::stream::empty();
 
-    let result = service.do_put_inner(stream).await;
+    let result = service
+      .do_put_inner(stream, &InterceptContext::default())
+      .await;
     assert!(result.is_err());
     assert_eq!(result.unwrap_err().code(), tonic::Code::InvalidArgument);
   }
@@ -2956,7 +3067,9 @@ mod tests {
     let flight_data: Vec<FlightData> = flight_stream.map(|r| r.unwrap()).collect().await;
     let stream = futures::stream::iter(flight_data.into_iter().map(Ok));
 
-    let result = service.do_put_inner(stream).await;
+    let result = service
+      .do_put_inner(stream, &InterceptContext::default())
+      .await;
     assert!(result.is_err());
     assert_eq!(result.unwrap_err().code(), tonic::Code::InvalidArgument);
   }

--- a/crates/sagitta/src/sql.rs
+++ b/crates/sagitta/src/sql.rs
@@ -30,7 +30,7 @@ use prost::Message;
 use tracing::{debug, info, warn};
 
 use crate::catalog::StoreCatalog;
-use crate::interceptor::{QueryInterception, SharedInterceptor};
+use crate::interceptor::{InterceptContext, QueryInterception, SharedInterceptor};
 use crate::provider::StoreTableProvider;
 
 /// Result type for SQL operations.
@@ -434,13 +434,27 @@ impl SqlEngine {
     &self,
     cmd: &CommandStatementQuery,
   ) -> SqlResult<QueryResult> {
+    self
+      .execute_statement_query_with_context(cmd, &InterceptContext::default())
+      .await
+  }
+
+  /// Execute a statement query command with request context.
+  ///
+  /// Identical to [`execute_statement_query`](Self::execute_statement_query),
+  /// but forwards `ctx` (the authenticated caller) to a registered interceptor.
+  pub async fn execute_statement_query_with_context(
+    &self,
+    cmd: &CommandStatementQuery,
+    ctx: &InterceptContext,
+  ) -> SqlResult<QueryResult> {
     let query = &cmd.query;
     debug!(query = %query, "executing statement query");
 
     // A registered interceptor may claim the query and supply its own result
     // schema. The data is produced later, when the ticket is fetched.
     if let Some(interceptor) = &self.interceptor
-      && let Some(interception) = interceptor.intercept_query(query).await?
+      && let Some(interception) = interceptor.intercept_query_with_context(ctx, query).await?
     {
       let handle = self.create_query_handle(query);
       info!(query = %query, "query schema resolved by interceptor");
@@ -524,6 +538,21 @@ impl SqlEngine {
     &self,
     ticket: &TicketStatementQuery,
   ) -> SqlResult<(SchemaRef, QueryDataStream)> {
+    self
+      .get_statement_query_data_stream_with_context(ticket, &InterceptContext::default())
+      .await
+  }
+
+  /// Get a streaming data source for a statement query ticket with request context.
+  ///
+  /// Identical to
+  /// [`get_statement_query_data_stream`](Self::get_statement_query_data_stream),
+  /// but forwards `ctx` (the authenticated caller) to a registered interceptor.
+  pub async fn get_statement_query_data_stream_with_context(
+    &self,
+    ticket: &TicketStatementQuery,
+    ctx: &InterceptContext,
+  ) -> SqlResult<(SchemaRef, QueryDataStream)> {
     let handle = &ticket.statement_handle;
     let query = String::from_utf8(handle.to_vec())
       .map_err(|_| SqlError::InvalidCommand("invalid query handle".to_string()))?;
@@ -533,7 +562,9 @@ impl SqlEngine {
     // If an interceptor claims the query, stream the batches it produced rather
     // than executing through DataFusion.
     if let Some(interceptor) = &self.interceptor
-      && let Some(interception) = interceptor.intercept_query(&query).await?
+      && let Some(interception) = interceptor
+        .intercept_query_with_context(ctx, &query)
+        .await?
     {
       let QueryInterception { schema, batches } = interception;
       let stream = MemoryStream::try_new(batches, schema.clone(), None)
@@ -573,6 +604,20 @@ impl SqlEngine {
     &self,
     cmd: &CommandStatementUpdate,
   ) -> SqlResult<UpdateResult> {
+    self
+      .execute_statement_update_with_context(cmd, &InterceptContext::default())
+      .await
+  }
+
+  /// Execute a statement update command with request context.
+  ///
+  /// Identical to [`execute_statement_update`](Self::execute_statement_update),
+  /// but forwards `ctx` (the authenticated caller) to a registered interceptor.
+  pub async fn execute_statement_update_with_context(
+    &self,
+    cmd: &CommandStatementUpdate,
+    ctx: &InterceptContext,
+  ) -> SqlResult<UpdateResult> {
     let query = &cmd.query;
     debug!(query = %query, transaction_id = ?cmd.transaction_id, "executing statement update");
 
@@ -580,7 +625,9 @@ impl SqlEngine {
     // statement reports its own affected-row count and bypasses the default
     // store-backed execution; transaction buffering does not apply to it.
     if let Some(interceptor) = &self.interceptor
-      && let Some(record_count) = interceptor.intercept_update(query).await?
+      && let Some(record_count) = interceptor
+        .intercept_update_with_context(ctx, query)
+        .await?
     {
       info!(query = %query, record_count, "update handled by interceptor");
       return Ok(UpdateResult { record_count });
@@ -3276,6 +3323,70 @@ mod tests {
 
     let result = engine.execute_statement_update(&cmd).await;
     assert!(matches!(result, Err(SqlError::Internal(_))));
+  }
+
+  /// Interceptor that records the principal it observed for each `DELETE`.
+  #[derive(Default)]
+  struct RecordingInterceptor {
+    seen: std::sync::Mutex<Vec<Option<String>>>,
+  }
+
+  #[async_trait::async_trait]
+  impl crate::interceptor::StatementInterceptor for RecordingInterceptor {
+    async fn intercept_update(&self, _sql: &str) -> SqlResult<Option<i64>> {
+      Ok(None)
+    }
+
+    async fn intercept_query(&self, _sql: &str) -> SqlResult<Option<QueryInterception>> {
+      Ok(None)
+    }
+
+    async fn intercept_update_with_context(
+      &self,
+      ctx: &InterceptContext,
+      sql: &str,
+    ) -> SqlResult<Option<i64>> {
+      if sql.contains("DELETE") {
+        self.seen.lock().unwrap().push(ctx.principal.clone());
+        return Ok(Some(1));
+      }
+      Ok(None)
+    }
+  }
+
+  #[tokio::test]
+  async fn test_interceptor_receives_request_principal() {
+    use arrow_flight::sql::CommandStatementUpdate;
+
+    let interceptor = Arc::new(RecordingInterceptor::default());
+    let mut engine = create_test_engine().await;
+    engine.set_interceptor(interceptor.clone());
+
+    let cmd = CommandStatementUpdate {
+      query: "DELETE FROM test.table WHERE id = 1".to_string(),
+      transaction_id: None,
+    };
+
+    // A populated context reaches the interceptor.
+    let ctx = InterceptContext {
+      principal: Some("alice".to_string()),
+      read_only: false,
+    };
+    let result = engine
+      .execute_statement_update_with_context(&cmd, &ctx)
+      .await
+      .unwrap();
+    assert_eq!(result.record_count, 1);
+
+    // The legacy method still routes through the context path with a default
+    // (empty) context, so existing callers keep working.
+    let result = engine.execute_statement_update(&cmd).await.unwrap();
+    assert_eq!(result.record_count, 1);
+
+    assert_eq!(
+      interceptor.seen.lock().unwrap().as_slice(),
+      &[Some("alice".to_string()), None]
+    );
   }
 
   #[tokio::test]


### PR DESCRIPTION
Promotes `test` → `main` (2 commits).

- feat(audit): keep scan-failure issues off the Engineering board (Decision #66) (#126)
- feat(interceptor): pass request context to StatementInterceptor (#128) (#129)

Closes #127
