### PR TITLE
Promote development → test (2 commits)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,9 +884,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/crates/sagitta/src/extension.rs
+++ b/crates/sagitta/src/extension.rs
@@ -1,0 +1,30 @@
+//! Embedder-registered DataFusion extensions for the SQL engine.
+
+use std::sync::Arc;
+
+use datafusion::prelude::SessionContext;
+
+/// Registers embedder DataFusion extensions on the engine's [`SessionContext`].
+///
+/// Implementors register `ScalarUDF`s, table functions, or optimizer rules so
+/// they participate in engine-planned SQL, complementing the whole-query
+/// [`StatementInterceptor`](crate::StatementInterceptor). Any closure of the
+/// form `Fn(&SessionContext) + Send + Sync` implements this trait.
+pub trait SessionExtension: Send + Sync {
+  /// Apply extensions to `ctx`.
+  ///
+  /// Called once, when the extension is registered on the engine.
+  fn apply(&self, ctx: &SessionContext);
+}
+
+impl<F> SessionExtension for F
+where
+  F: Fn(&SessionContext) + Send + Sync,
+{
+  fn apply(&self, ctx: &SessionContext) {
+    self(ctx)
+  }
+}
+
+/// Shared handle to a registered [`SessionExtension`].
+pub type SharedSessionExtension = Arc<dyn SessionExtension>;

--- a/crates/sagitta/src/lib.rs
+++ b/crates/sagitta/src/lib.rs
@@ -6,6 +6,7 @@ mod auth;
 mod catalog;
 mod config;
 mod error;
+mod extension;
 mod interceptor;
 mod memory;
 mod metadata;
@@ -20,6 +21,7 @@ mod types;
 pub use auth::{AccessLevel, AuthToken, InMemoryUserStore, User, UserStore};
 pub use config::{Config, LoggingConfig, ServerConfig, TlsConfig};
 pub use error::{Error, Result};
+pub use extension::{SessionExtension, SharedSessionExtension};
 pub use interceptor::{
   InterceptContext, QueryInterception, SharedInterceptor, StatementInterceptor,
 };

--- a/crates/sagitta/src/server.rs
+++ b/crates/sagitta/src/server.rs
@@ -20,6 +20,7 @@ use tonic::transport::{Identity, Server, ServerTlsConfig};
 use tracing::info;
 
 use crate::config::Config;
+use crate::extension::SharedSessionExtension;
 use crate::interceptor::SharedInterceptor;
 use crate::service::{CustomAction, SagittaService};
 
@@ -160,6 +161,7 @@ pub struct Sagitta {
   user_store: Option<Arc<dyn UserStore>>,
   custom_actions: Vec<Arc<dyn CustomAction>>,
   interceptor: Option<SharedInterceptor>,
+  session_extension: Option<SharedSessionExtension>,
 }
 
 impl Sagitta {
@@ -171,6 +173,7 @@ impl Sagitta {
       user_store: None,
       custom_actions: Vec::new(),
       interceptor: None,
+      session_extension: None,
     }
   }
 
@@ -202,6 +205,15 @@ impl Sagitta {
   /// by the SQL engine before its default statement handling.
   pub fn interceptor(mut self, interceptor: SharedInterceptor) -> Self {
     self.interceptor = Some(interceptor);
+    self
+  }
+
+  /// Register a [`SessionExtension`](crate::SessionExtension) that applies
+  /// embedder DataFusion extensions (`ScalarUDF`s, table functions, optimizer
+  /// rules) to the SQL engine's
+  /// [`SessionContext`](datafusion::prelude::SessionContext).
+  pub fn session_extension(mut self, extension: SharedSessionExtension) -> Self {
+    self.session_extension = Some(extension);
     self
   }
 
@@ -241,6 +253,10 @@ impl Sagitta {
 
     if let Some(interceptor) = self.interceptor {
       service = service.with_interceptor(interceptor);
+    }
+
+    if let Some(extension) = self.session_extension {
+      service = service.with_session_extension(extension);
     }
 
     for action in self.custom_actions {

--- a/crates/sagitta/src/service.rs
+++ b/crates/sagitta/src/service.rs
@@ -32,6 +32,7 @@ use tonic::{Request, Response, Status, Streaming};
 use tracing::{debug, info, warn};
 use x509_parser::prelude::*;
 
+use crate::extension::SharedSessionExtension;
 use crate::interceptor::{InterceptContext, SharedInterceptor};
 use crate::metadata::{DEFAULT_CATALOG, DEFAULT_SCHEMA, MetadataEngine, MetadataQuery};
 use crate::sql::{
@@ -161,6 +162,14 @@ impl SagittaService {
   /// for chaining.
   pub fn with_interceptor(mut self, interceptor: SharedInterceptor) -> Self {
     self.sql_engine.set_interceptor(interceptor);
+    self
+  }
+
+  /// Register a [`SessionExtension`](crate::SessionExtension) applied to the
+  /// SQL engine's [`SessionContext`](datafusion::prelude::SessionContext).
+  /// Returns `self` for chaining.
+  pub fn with_session_extension(mut self, extension: SharedSessionExtension) -> Self {
+    self.sql_engine.set_session_extension(extension);
     self
   }
 

--- a/crates/sagitta/src/sql.rs
+++ b/crates/sagitta/src/sql.rs
@@ -30,6 +30,7 @@ use prost::Message;
 use tracing::{debug, info, warn};
 
 use crate::catalog::StoreCatalog;
+use crate::extension::SharedSessionExtension;
 use crate::interceptor::{InterceptContext, QueryInterception, SharedInterceptor};
 use crate::provider::StoreTableProvider;
 
@@ -345,6 +346,19 @@ impl SqlEngine {
   /// interceptor.
   pub fn set_interceptor(&mut self, interceptor: SharedInterceptor) {
     self.interceptor = Some(interceptor);
+  }
+
+  /// Register a [`SessionExtension`](crate::SessionExtension) that applies
+  /// embedder DataFusion extensions (`ScalarUDF`s, table functions, optimizer
+  /// rules) to the engine's live [`SessionContext`].
+  ///
+  /// The extension is applied exactly once, to the current context. Registered
+  /// extensions survive catalog refreshes because [`refresh_tables`] re-registers
+  /// the catalog on the existing context rather than recreating it.
+  ///
+  /// [`refresh_tables`]: Self::refresh_tables
+  pub fn set_session_extension(&mut self, extension: SharedSessionExtension) {
+    extension.apply(&self.ctx.read().unwrap());
   }
 
   /// Create a new SessionContext with our catalog configured as the default.
@@ -3229,6 +3243,53 @@ mod tests {
   async fn create_fixture_engine() -> SqlEngine {
     let store: Arc<dyn Store> = Arc::new(MemoryStore::with_test_fixtures());
     SqlEngine::new(store, DEFAULT_CATALOG, DEFAULT_SCHEMA).await
+  }
+
+  #[tokio::test]
+  async fn test_session_extension_udf_usable_and_survives_refresh() {
+    use arrow_array::Array;
+    use datafusion::logical_expr::{ColumnarValue, Volatility, create_udf};
+
+    let mut engine = create_test_engine().await;
+    engine.set_session_extension(Arc::new(|ctx: &SessionContext| {
+      let double_it = create_udf(
+        "double_it",
+        vec![DataType::Int64],
+        DataType::Int64,
+        Volatility::Immutable,
+        Arc::new(|args: &[ColumnarValue]| {
+          let array = args[0].clone().into_array(1)?;
+          let ints = array.as_any().downcast_ref::<Int64Array>().unwrap();
+          let doubled: Int64Array = ints.iter().map(|v| v.map(|x| x * 2)).collect();
+          Ok(ColumnarValue::Array(Arc::new(doubled)))
+        }),
+      );
+      ctx.register_udf(double_it);
+    }));
+
+    async fn eval(engine: &SqlEngine) -> i64 {
+      let batches = engine
+        .session_ctx()
+        .sql("SELECT double_it(21) AS r")
+        .await
+        .unwrap()
+        .collect()
+        .await
+        .unwrap();
+      batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .unwrap()
+        .value(0)
+    }
+
+    // Usable inside a standard SELECT planned by the engine.
+    assert_eq!(eval(&engine).await, 42);
+
+    // Survives a catalog refresh.
+    engine.refresh_tables().await;
+    assert_eq!(eval(&engine).await, 42);
   }
 
   /// Test interceptor that claims statements containing specific markers.


### PR DESCRIPTION
Promotes `development` → `test` (2 commits).

- chore(deps): bump crossbeam-epoch for RUSTSEC-2026-0204 (#142)
- feat(sql): DataFusion session-extension hook for embedder UDFs/UDTFs (#143)

Refs #122
Refs #121
Refs #123
