### PR TITLE
test(sql): cover session-extension builder and service wiring

### DIFF
--- a/crates/sagitta/src/server.rs
+++ b/crates/sagitta/src/server.rs
@@ -417,6 +417,14 @@ mod tests {
   }
 
   #[test]
+  fn test_builder_with_session_extension() {
+    use datafusion::prelude::SessionContext;
+
+    let sagitta = Sagitta::builder().session_extension(Arc::new(|_ctx: &SessionContext| {}));
+    assert!(sagitta.session_extension.is_some());
+  }
+
+  #[test]
   fn test_load_tls_config_missing_cert_file() {
     let tls = crate::config::TlsConfig {
       cert_path: "/nonexistent/cert.pem".to_string(),

--- a/crates/sagitta/src/service.rs
+++ b/crates/sagitta/src/service.rs
@@ -2050,6 +2050,42 @@ mod tests {
     assert_eq!(result.record_count, 5);
   }
 
+  #[tokio::test]
+  async fn test_with_session_extension_wires_sql_engine() {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use datafusion::prelude::SessionContext;
+
+    let applied = Arc::new(AtomicBool::new(false));
+    let applied_cb = applied.clone();
+
+    let store: Arc<dyn crate::Store> = Arc::new(crate::MemoryStore::new());
+    let service =
+      SagittaService::with_user_store(store, Arc::new(InMemoryUserStore::with_test_users()))
+        .await
+        .with_session_extension(Arc::new(move |_ctx: &SessionContext| {
+          applied_cb.store(true, Ordering::SeqCst);
+        }));
+
+    // The callback runs against the engine's live SessionContext at registration.
+    assert!(
+      applied.load(Ordering::SeqCst),
+      "session extension callback should run when registered"
+    );
+
+    // Engine remains usable afterwards.
+    let batches = service
+      .sql_engine
+      .session_ctx()
+      .sql("SELECT 1 AS n")
+      .await
+      .unwrap()
+      .collect()
+      .await
+      .unwrap();
+    assert_eq!(batches[0].num_rows(), 1);
+  }
+
   #[test]
   fn test_intercept_context_from_user() {
     let full = User::new("alice", AccessLevel::FullAccess);


### PR DESCRIPTION
Restores patch coverage after the DataFusion extension-hook (#123) landed slightly below 80% (79.63%): `server.rs` builder method and `service.rs` `with_session_extension` were uncovered.

Adds two unit tests:
- `test_builder_with_session_extension` — asserts `Sagitta::builder().session_extension(..)` sets the option.
- `test_with_session_extension_wires_sql_engine` — asserts the callback runs against the engine's live `SessionContext` at registration and the engine stays usable.

Verified via `cargo llvm-cov` that the builder method (`server.rs` 215-217) and `with_session_extension` (`service.rs` 171-174) are now hit. The only remaining uncovered lines are the `serve()` service-assembly block (interceptor + extension wiring), which can't be unit-tested without binding a server — consistent with the pre-existing interceptor wiring there.

Refs #123