### PR TITLE
chore(deps): re-pin debian:trixie-slim to current digest

### DIFF
--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -1,7 +1,7 @@
 # Multi-arch release Dockerfile
 # Expects pre-built binaries in binaries/linux/{amd64,arm64}/
 
-FROM debian:trixie-slim@sha256:b6e2a152f22a40ff69d92cb397223c906017e1391a73c952b588e51af8883bf8
+FROM debian:trixie-slim@sha256:020c0d20b9880058cbe785a9db107156c3c75c2ac944a6aa7ab59f2add76a7bd
 
 ARG TARGETARCH
 


### PR DESCRIPTION
The debian:trixie-slim tag was rebuilt upstream, so the pinned digest no
longer resolves. Re-pin to the current digest (verified with docker buildx
imagetools inspect); no version change.
