### PR TITLE
Promote development → test (3 commits)

### DIFF
--- a/crates/sagitta/src/server.rs
+++ b/crates/sagitta/src/server.rs
@@ -417,6 +417,14 @@ mod tests {
   }
 
   #[test]
+  fn test_builder_with_session_extension() {
+    use datafusion::prelude::SessionContext;
+
+    let sagitta = Sagitta::builder().session_extension(Arc::new(|_ctx: &SessionContext| {}));
+    assert!(sagitta.session_extension.is_some());
+  }
+
+  #[test]
   fn test_load_tls_config_missing_cert_file() {
     let tls = crate::config::TlsConfig {
       cert_path: "/nonexistent/cert.pem".to_string(),

--- a/crates/sagitta/src/service.rs
+++ b/crates/sagitta/src/service.rs
@@ -2050,6 +2050,42 @@ mod tests {
     assert_eq!(result.record_count, 5);
   }
 
+  #[tokio::test]
+  async fn test_with_session_extension_wires_sql_engine() {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use datafusion::prelude::SessionContext;
+
+    let applied = Arc::new(AtomicBool::new(false));
+    let applied_cb = applied.clone();
+
+    let store: Arc<dyn crate::Store> = Arc::new(crate::MemoryStore::new());
+    let service =
+      SagittaService::with_user_store(store, Arc::new(InMemoryUserStore::with_test_users()))
+        .await
+        .with_session_extension(Arc::new(move |_ctx: &SessionContext| {
+          applied_cb.store(true, Ordering::SeqCst);
+        }));
+
+    // The callback runs against the engine's live SessionContext at registration.
+    assert!(
+      applied.load(Ordering::SeqCst),
+      "session extension callback should run when registered"
+    );
+
+    // Engine remains usable afterwards.
+    let batches = service
+      .sql_engine
+      .session_ctx()
+      .sql("SELECT 1 AS n")
+      .await
+      .unwrap()
+      .collect()
+      .await
+      .unwrap();
+    assert_eq!(batches[0].num_rows(), 1);
+  }
+
   #[test]
   fn test_intercept_context_from_user() {
     let full = User::new("alice", AccessLevel::FullAccess);

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@
 # Use Dockerfile.release for production with pre-built binaries
 
 # Stage 1: Plan dependencies
-FROM rust:1.95-alpine3.23@sha256:606fd313a0f49743ee2a7bd49a0914bab7deedb12791f3a846a34a4711db7ed2 AS planner
+FROM rust:1.97-alpine3.23@sha256:ca0daf101eef0c8cd1e49dfc137154a220efb8c458c85a3eacacc7dfd5d9e04c AS planner
 RUN cargo install cargo-chef --locked
 WORKDIR /build
 COPY Cargo.toml Cargo.lock ./
@@ -11,7 +11,7 @@ COPY crates ./crates
 RUN cargo chef prepare --recipe-path recipe.json
 
 # Stage 2: Cache dependencies
-FROM rust:1.95-alpine3.23@sha256:606fd313a0f49743ee2a7bd49a0914bab7deedb12791f3a846a34a4711db7ed2 AS cacher
+FROM rust:1.97-alpine3.23@sha256:ca0daf101eef0c8cd1e49dfc137154a220efb8c458c85a3eacacc7dfd5d9e04c AS cacher
 RUN apk add --no-cache musl-dev
 RUN cargo install cargo-chef --locked
 WORKDIR /build
@@ -20,7 +20,7 @@ COPY --from=planner /build/recipe.json recipe.json
 RUN cargo chef cook --release --recipe-path recipe.json
 
 # Stage 3: Build application
-FROM rust:1.95-alpine3.23@sha256:606fd313a0f49743ee2a7bd49a0914bab7deedb12791f3a846a34a4711db7ed2 AS builder
+FROM rust:1.97-alpine3.23@sha256:ca0daf101eef0c8cd1e49dfc137154a220efb8c458c85a3eacacc7dfd5d9e04c AS builder
 RUN apk add --no-cache musl-dev
 WORKDIR /build
 # Copy cached dependencies

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -1,7 +1,7 @@
 # Multi-arch release Dockerfile
 # Expects pre-built binaries in binaries/linux/{amd64,arm64}/
 
-FROM debian:trixie-slim@sha256:b6e2a152f22a40ff69d92cb397223c906017e1391a73c952b588e51af8883bf8
+FROM debian:trixie-slim@sha256:020c0d20b9880058cbe785a9db107156c3c75c2ac944a6aa7ab59f2add76a7bd
 
 ARG TARGETARCH
 


### PR DESCRIPTION
Promotes `development` → `test` (3 commits).

- test(sql): cover session-extension builder and service wiring (#146)
- chore(deps): re-pin debian:trixie-slim to current digest (#147)
- chore(deps): bump rust builder 1.95 -> 1.97 (#148)

Refs #123
