### PR TITLE
chore(release): bump patch version to 0.1.12 (#151)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3265,7 +3265,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "sagitta"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/sagitta"]
 
 [workspace.package]
-version = "0.1.11"
+version = "0.1.12"
 edition = "2024"
 description = "Rust framework for building analytical data services on Arrow Flight and DataFusion."
 license = "Apache-2.0"


### PR DESCRIPTION
Promotes `development` → `test` (1 commit).

- chore(release): bump patch version to 0.1.12 (#151)