### PR TITLE
Promote development → test (4 commits)

### DIFF
--- a/.github/instructions/commit.instructions.md
+++ b/.github/instructions/commit.instructions.md
@@ -57,9 +57,13 @@ Improves UX for returning users.
 
 **Board issues:** when a commit advances an engineering-board issue, add a `Refs: #N` trailer (one
 issue per line for several). The `git-merge` promotion script harvests these from the promoted
-commit range and self-documents the promotion PRs — as `Closes #N` on the hop into the default
-branch (so the issue auto-closes on release) and `Refs #N` on intermediate hops. Use `Closes: #N` in
-the commit itself only when merging that commit directly should close the issue.
+commit range and self-documents the promotion PRs. The harvester **preserves the keyword — it never
+upgrades a `Refs` to a `Closes`.** A reference is emitted as `Closes #N` only when the commit wrote
+a closing keyword (`Closes`/`Fixes`/`Resolves`), and only on the hop into the default branch (so the
+issue auto-closes on release); a deliberate `Refs #N` stays `Refs #N` on every hop, including the
+final one. Intermediate hops always emit `Refs #N`. So: use `Closes:`/`Fixes:`/`Resolves:` only when
+that commit genuinely completes the issue; use `Refs:` for partial progress you don't want
+auto-closed, and it will never be promoted to a close.
 
 **Example**
 

--- a/.github/instructions/pr.instructions.md
+++ b/.github/instructions/pr.instructions.md
@@ -43,7 +43,12 @@ Refs #456
   - Scan every commit subject/body in the range for `Close[sd]?`, `Fix(e[sd])?`, `Resolve[sd]?`, or
     `Refs?` (case-insensitive, with or without a trailing colon) followed by `#123` or
     `owner/repo#123`. De-duplicate, first-seen order.
-  - Emit as `Closes #N` when the PR's base branch is the repo's default branch (so the issue
-    auto-closes on merge); emit as `Refs #N` for every other base branch (so the reference is
-    visible without prematurely closing anything).
+  - **The trailer keyword is preserved, never upgraded.** A reference becomes `Closes #N` only when
+    it was written with a closing keyword (`Closes`/`Fixes`/`Resolves`) somewhere in the range AND
+    the PR's base is the repo's default branch (so the issue auto-closes on merge). A deliberate
+    `Refs #N` stays `Refs #N` on every base branch — including the default — so partial-progress
+    work referenced with `Refs` is never auto-closed. Use `Refs` (not a closing keyword) whenever a
+    commit only advances an issue without completing it.
+  - Every reference emits as `Refs #N` on a base branch that is not the repo's default branch, so
+    the reference is visible without prematurely closing anything.
 - Omit the references block entirely if no issues were referenced in the range. </content>

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -203,6 +203,7 @@ jobs:
     needs: [docker, publish-crate]
     permissions:
       contents: write
+      pull-requests: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -258,10 +259,10 @@ jobs:
 
           PROMOTION_TITLE = re.compile(r"^(Promote .* → .* \(\d+ commits?\)|Merge .* into (main|test|development))")
           LEAF_EXCLUDE = [
-              re.compile(r"^docs:"),
-              re.compile(r"^test:"),
-              re.compile(r"^chore:"),
-              re.compile(r"^ci:"),
+              re.compile(r"^docs(\(.+\))?!?:"),
+              re.compile(r"^test(\(.+\))?!?:"),
+              re.compile(r"^chore(\(.+\))?!?:"),
+              re.compile(r"^ci(\(.+\))?!?:"),
               re.compile(r"Merge pull request"),
               re.compile(r"Merge branch"),
           ]
@@ -275,6 +276,10 @@ jobs:
                   cmd += ["-f", f"{k}={v}"]
               out = subprocess.run(cmd, capture_output=True, text=True)
               if out.returncode != 0:
+                  # Surface the failure so a permission/auth/rate-limit error (which would
+                  # otherwise silently degrade every promotion PR to a bare commit entry)
+                  # is visible in the log rather than producing wrong-but-green notes.
+                  print(f"warning: gh api {path} failed: {out.stderr.strip()}", file=sys.stderr)
                   return None, out.stderr
               return json.loads(out.stdout), None
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -257,7 +257,11 @@ jobs:
           import subprocess
           import sys
 
-          PROMOTION_TITLE = re.compile(r"^(Promote .* → .* \(\d+ commits?\)|Merge .* into (main|test|development))")
+          # Promotion-hop PRs come in a couple of title shapes: dx git merge synthesises
+          # "Promote <src> → <dst> (N commits)" (Unicode arrow + count), but older/manual
+          # promotions use a bare "Promote <src> -> <dst>" (ASCII arrow, no count). Match
+          # both arrows and treat the count as optional so neither slips through as a leaf.
+          PROMOTION_TITLE = re.compile(r"^(Promote .* (?:→|->) .*|Merge .* into (main|test|development))")
           LEAF_EXCLUDE = [
               re.compile(r"^docs(\(.+\))?!?:"),
               re.compile(r"^test(\(.+\))?!?:"),

--- a/.github/workflows/tag-on-release.yaml
+++ b/.github/workflows/tag-on-release.yaml
@@ -5,23 +5,22 @@ name: Tag on Release
 
 # Producer half of the tag-driven release flow. The release.yaml in each repo
 # is the CONSUMER (triggered by `push: tags`); this workflow is the PRODUCER:
-# it creates the tag, but only after CI has gone green on main and only on a
-# commit that is actually on main.
+# it creates the tag on a commit that has landed on main.
 #
-# Trigger is `workflow_run` (not `push`) so the tag is cut strictly AFTER the
-# main branch's CI has succeeded. The version source of truth is the repo's
-# manifest (package.json / Cargo.toml / tauri.conf.json / VERSION); a normal
-# merge that does not change the version is a no-op because the tag already
-# exists.
+# Trigger is `push: [main]`: the tag is cut once a commit lands on main. Every
+# such commit already passed CI on its PR (CI runs on `pull_request` into
+# main/test), so gating on a main CI run is unnecessary — and impossible, since
+# CI has no `push: [main]` trigger. The version source of truth is the repo's
+# manifest (package.json / Cargo.toml / tauri.conf.json / VERSION); a push that
+# does not change the version is a no-op because the tag already exists, so this
+# is safe to run on every push to main.
 #
 # The tag MUST be pushed with the qualithm-ci App token, not GITHUB_TOKEN —
 # tags pushed with GITHUB_TOKEN do not trigger downstream workflows, so
 # release.yaml would never fire.
 
 on:
-  workflow_run:
-    workflows: ["CI"]
-    types: [completed]
+  push:
     branches: [main]
   workflow_dispatch: {}
 
@@ -36,12 +35,6 @@ jobs:
   tag:
     name: Tag main when version changes
     runs-on: ubuntu-24.04
-    # Only act on a successful CI run for main. workflow_dispatch (manual) is
-    # also allowed so a missed tag can be reconciled by hand.
-    if: >
-      github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success'
-      &&
-       github.event.workflow_run.head_branch == 'main')
     steps:
       - name: Generate GitHub App token
         id: app-token
@@ -53,10 +46,10 @@ jobs:
       - name: Checkout main commit
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          # For workflow_run the triggering commit is the CI head_sha; for a
-          # manual dispatch fall back to the branch tip. fetch-depth 0 + tags so
-          # we can detect an already-released version.
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          # github.sha is the pushed main commit (or the branch tip on manual
+          # dispatch). fetch-depth 0 + tags so we can detect an already-released
+          # version.
+          ref: ${{ github.sha }}
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 


### PR DESCRIPTION
Promotes `development` → `test` (4 commits).

- ci(release): grant pull-requests read for changelog note generation
- docs(instructions): note Refs is never auto-promoted to Closes on the final hop
- ci(tag-on-release): trigger on push to main so tags auto-cut without manual dispatch
- ci(release): recognise ASCII-arrow promotion titles in changelog notes