### PR TITLE
chore: sync report-scan-failure action + off-board marker from dx (#159)

### DIFF
--- a/.github/ISSUE_TEMPLATE/work.yaml
+++ b/.github/ISSUE_TEMPLATE/work.yaml
@@ -6,8 +6,9 @@ body:
   - type: markdown
     attributes:
       value: |
-        One uniform format so any work can be picked up cold. Set **Initiative**, **Size**, and
-        **Status** on the Engineering board after opening. Keep the running state in **comments**
+        One uniform format so any work can be picked up cold. Set **Initiative**, **Size**
+        (agent-session effort: XS one-file tweak → XL split-before-pickup), and **Status** on the
+        Engineering board after opening. Keep the running state in **comments**
         (end each session with a Snapshot comment, posted via `dx project snapshot` for a consistent
         format).
   - type: textarea

--- a/.github/actions/report-scan-failure/action.yaml
+++ b/.github/actions/report-scan-failure/action.yaml
@@ -2,14 +2,14 @@
 
 name: "Report or resolve scan failure"
 description: >
-  Files (or bumps) a `security-audit`-labeled issue when a scheduled scan step genuinely fails, or
-  closes it once the scan is green again and nobody has claimed it yet. Dedupes on the issue title,
-  so re-runs of a still-failing scan never pile up duplicate issues. The label deliberately keeps
-  these off the Engineering board by default (Decision #66) — promote one manually with `dx project
-  add` if it turns into real, multi-session work.
+  Files (or bumps) a labelled issue when an automated check reports a problem, or closes it once the
+  check is healthy again and nobody has claimed it yet. Dedupes on the issue title, so re-runs never
+  pile up duplicate issues. The default `security-audit` label (and the `off-board` label) keep
+  these off the Engineering board (Decision #66) — promote one manually with `dx project add` if it
+  turns into real, multi-session work.
 inputs:
   mode:
-    description: "report (scan just failed) or resolve (scan just passed)"
+    description: "report (check just failed) or resolve (check just passed)"
     required: true
   title:
     description: "Stable anchor used as both the issue title and the dedup key."
@@ -17,6 +17,18 @@ inputs:
   github-token:
     description: "Token with this repo's issues:write (e.g. secrets.GITHUB_TOKEN)."
     required: true
+  label:
+    description: >
+      Space/comma-separated labels to apply and dedup under (default: security-audit). Include an
+      off-board marker (security-audit or off-board) to keep the issue off the Engineering board.
+    required: false
+    default: "security-audit"
+  body:
+    description:
+      "Issue body used when filing a new issue in mode=report. Defaults to a generic scan-failure
+      body."
+    required: false
+    default: ""
   run-url:
     description: "URL of the workflow run to link from the issue (mode: report)."
     required: false
@@ -30,5 +42,7 @@ runs:
         REPO: ${{ github.repository }}
         MODE: ${{ inputs.mode }}
         TITLE: ${{ inputs.title }}
+        LABELS: ${{ inputs.label }}
+        BODY: ${{ inputs.body }}
         RUN_URL: ${{ inputs.run-url }}
       run: ${{ github.action_path }}/run.sh

--- a/.github/actions/report-scan-failure/run.sh
+++ b/.github/actions/report-scan-failure/run.sh
@@ -5,24 +5,49 @@ set -euo pipefail
 
 : "${REPO:?}" "${MODE:?}" "${TITLE:?}"
 
+# Labels to apply and dedup under; accept space- or comma-separated input.
+LABELS="${LABELS:-security-audit}"
+LABELS="${LABELS//,/ }"
+
 existing="$(gh issue list --repo "$REPO" --state open --search "\"${TITLE}\"" \
   --json number,title --jq "[.[] | select(.title == \"${TITLE}\")][0].number // empty")"
 
 case "$MODE" in
 report)
-  # security-audit deliberately keeps these off the Engineering board (issue-templates/
-  # add-to-project.yaml excludes it) — see Decision #66:
-  # https://github.com/orgs/qualithm/discussions/66. The label must exist before `gh issue
-  # create --label` can attach it, so ensure it every run; --force makes this idempotent.
-  gh label create security-audit --repo "$REPO" --color "b60205" --force \
-    --description "Automated scan failure filed by report-scan-failure; kept off the Engineering board (Decision #66)" \
-    >/dev/null
+  # Ensure every requested label exists before `gh issue create --label` can
+  # attach it. `security-audit` and `off-board` are the off-the-Engineering-board
+  # markers (issue-templates/add-to-project.yaml excludes both) and keep their
+  # canonical styling; see Decision #66:
+  # https://github.com/orgs/qualithm/discussions/66. Any other label is created
+  # if missing with a neutral colour. --force makes the marker creates idempotent.
+  for l in $LABELS; do
+    case "$l" in
+    security-audit)
+      gh label create security-audit --repo "$REPO" --color "b60205" --force \
+        --description "Automated scan failure filed by report-scan-failure; kept off the Engineering board (Decision #66)" \
+        >/dev/null
+      ;;
+    off-board)
+      gh label create off-board --repo "$REPO" --color "5319e7" --force \
+        --description "Automation-filed issue kept off the Engineering board (Decision #66)" \
+        >/dev/null
+      ;;
+    *)
+      gh label create "$l" --repo "$REPO" --color "ededed" >/dev/null 2>&1 || true
+      ;;
+    esac
+  done
+
+  label_args=()
+  for l in $LABELS; do label_args+=(--label "$l"); done
 
   if [[ -n "$existing" ]]; then
     gh issue comment "$existing" --repo "$REPO" --body "Still failing as of ${RUN_URL}."
     echo "report-scan-failure: bumped existing issue #${existing}"
   else
-    body="### Why
+    body="${BODY:-}"
+    if [[ -z "$body" ]]; then
+      body="### Why
 The scheduled scan is failing, which means it found something real rather than a one-off flake
 — someone needs to look at the failing run and fix the underlying problem.
 
@@ -38,7 +63,8 @@ addressing the finding.
 
 ### Links
 - Failing run: ${RUN_URL}"
-    url="$(gh issue create --repo "$REPO" --title "$TITLE" --body "$body" --label security-audit)"
+    fi
+    url="$(gh issue create --repo "$REPO" --title "$TITLE" --body "$body" "${label_args[@]}")"
     echo "report-scan-failure: filed ${url}"
   fi
   ;;

--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -17,7 +17,8 @@ jobs:
         with:
           project-url: https://github.com/orgs/qualithm/projects/3
           github-token: ${{ steps.app.outputs.token }}
-          # Automated scan-failure issues (report-scan-failure) stay off the board by
-          # default — see Decision #66: https://github.com/orgs/qualithm/discussions/66.
-          labeled: security-audit
+          # Automation-filed issues (report-scan-failure) stay off the board by default:
+          # security-audit marks scan failures, off-board marks other automation (e.g.
+          # IRM alerts) — see Decision #66: https://github.com/orgs/qualithm/discussions/66.
+          labeled: security-audit,off-board
           label-operator: NOT


### PR DESCRIPTION
Promotes `development` → `test` (1 commit).

- chore: sync report-scan-failure action + off-board marker from dx (#159)