### PR TITLE
ci(workflows): make PR runs restore-only for rust-cache (#174) (#175)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,6 +72,11 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: "dev"
+          # PRs restore but never save. A PR-run cache is scoped to refs/pull/N/merge,
+          # which no other branch can read and which dies with the PR — so saving one
+          # only churns the repo's 10GB LRU budget and evicts the main-scoped cache
+          # every PR actually restores from.
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - run: cargo fmt --all -- --check
       - run: cargo check --workspace --all-targets
       - run: cargo clippy --workspace --all-targets -- -D warnings
@@ -100,6 +105,7 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: "coverage"
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@cargo-llvm-cov
       - run: cargo llvm-cov --workspace --lcov --output-path lcov.info
       - name: Enforce coverage threshold (>=80%)
@@ -134,6 +140,7 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: "doc"
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - run: cargo doc --workspace --no-deps
         env:
           RUSTDOCFLAGS: "-Dwarnings"
@@ -157,6 +164,9 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: "bench"
+          # This job is PR-only, so this is always false: restore-only. The bench key
+          # is seeded by the Benchmark Baseline job on push to main.
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - name: Restore baseline from main
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:


### PR DESCRIPTION
Promotes `test` → `main` (1 commit).

- ci(workflows): make PR runs restore-only for rust-cache (#174) (#175)

Refs #194
