### PR TITLE
chore(release): bump patch version to 0.1.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3265,7 +3265,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "sagitta"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "arrow-array",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/sagitta"]
 
 [workspace.package]
-version = "0.1.12"
+version = "0.1.13"
 edition = "2024"
 description = "Rust framework for building analytical data services on Arrow Flight and DataFusion."
 license = "Apache-2.0"


### PR DESCRIPTION
Cuts 0.1.13 so the handshake fix in #178 is consumable.

arrow-rs's `FlightSqlServiceClient::handshake` sends an empty `HandshakeRequest` payload and puts the credentials in an `authorization: Basic <base64>` header. Sagitta only decoded `BasicAuth` from the payload, so those clients got no bearer token back and every subsequent RPC failed with `missing authorization header`. #178 accepts both forms.

varv-rs needs the released crate to rebuild its server image and finish the performance baseline in qualithm/varv-rs#130.

Version only — `Cargo.toml` plus the matching `Cargo.lock` entry.